### PR TITLE
Fix "Download as resume.json" for Firefox users

### DIFF
--- a/js/file.js
+++ b/js/file.js
@@ -26,9 +26,7 @@ var save = (function() {
           // Create Click event
           var clickEvent = document.createEvent("MouseEvent");
           clickEvent.initMouseEvent("click", true, true, window, 0,
-            event.screenX, event.screenY, event.clientX, event.clientY,
-            event.ctrlKey, event.altKey, event.shiftKey, event.metaKey,
-            0, null);
+            0, 0, 0, 0, false, false, false, false, 0, null);
 
           // dispatch click event to simulate download
           a.dispatchEvent(clickEvent);


### PR DESCRIPTION
Hi there,

In Firefox, clicking the Download button triggers a ReferenceError:

```
ReferenceError: event is not defined file.js:29
```

Indeed there is no `event` variable here. I modified the mouse event initialization to use dummy values (`0` and `false`), and it now works as intended.
- Before: on OSX 10.9, Chrome 39 (OK), Safari 7 (OK), Firefox 34 (KO)
- After : on OSX 10.9, Chrome 39 (OK), Safari 7 (OK), Firefox 34 (**OK**)

Thanks for this tool by the way!
